### PR TITLE
WA-44 - wigetDay.js safari fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 /dist
 
+#Firebase files
+.cache
 
 # local env files
 .env.local

--- a/src/composables/widgetDay.js
+++ b/src/composables/widgetDay.js
@@ -9,9 +9,10 @@ export default function(date) {
     "Saturday",
     "Sunday",
   ];
+  date = date.replace(/-/g, "/"); // Fix for Safari browser - for some reason doesn't like the default date format from javascript.
   const setDate = new Date(date);
   const day = setDate.getDay();
-  let weekday = weekdays[day]; // Full day name
+  let weekday = weekdays[Number(day)]; // Full day name
   weekday = weekday.substring(0,3); // Create short name - e.g Friday --> Fri
   return weekday;
 }


### PR DESCRIPTION
- Applied specific fix for safari browser
    - replace "-" with "/" from format day
- Added firebase .cache files to gitignore 